### PR TITLE
tftp stale timers

### DIFF
--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -264,7 +264,12 @@ int gnrc_tftp_client_read(ipv6_addr_t *addr, const char *file_name,
     }
 
     /* start the process */
-    return _tftp_do_client_transfer(&ctxt);
+    int ret = _tftp_do_client_transfer(&ctxt);
+
+    /* remove possibly stale timer */
+    xtimer_remove(&(ctxt.timer));
+
+    return ret;
 }
 
 int gnrc_tftp_client_write(ipv6_addr_t *addr, const char *file_name,
@@ -283,7 +288,12 @@ int gnrc_tftp_client_write(ipv6_addr_t *addr, const char *file_name,
     }
 
     /* start the process */
-    return _tftp_do_client_transfer(&ctxt);
+    int ret = _tftp_do_client_transfer(&ctxt);
+
+    /* remove possibly stale timer */
+    xtimer_remove(&(ctxt.timer));
+
+    return ret;
 }
 
 #define INT_DIGITS 6


### PR DESCRIPTION
After `_tftp_do_client_transfer()` there may still be active timers. I guess because of an early return or in some error cases. As the [tftp_context_t ctxt](https://github.com/DipSwitch/RIOT/blob/9d0af0aa86474784b7342e2ec4e3567e1e65218b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c#L253), which holds the timer struct, is located on the stack it's dangerous to have running timers. I was getting hardfaults that were caused by a corrupted timer callback.

This PR fixes the issue in the sense that the timer will be removed after calling `_tftp_do_client_transfer()` to be sure that this cannot happen anymore. But maybe you should revise your timeout handling.
